### PR TITLE
fix: leaked dev servers and truncated new READMEs

### DIFF
--- a/scripts/benchmark/dev_server.py
+++ b/scripts/benchmark/dev_server.py
@@ -4,6 +4,7 @@
 import json
 import os
 import re
+import signal
 import subprocess
 import tempfile
 import time
@@ -244,6 +245,30 @@ class DevServerRunner(BenchmarkRunner):
         
         return 0.0, 0.0
     
+    def _terminate_process_group(self, process: subprocess.Popen, framework: str):
+        """Stop a dev server, including children spawned by the wrapping shell."""
+        try:
+            group_id = os.getpgid(process.pid)
+        except Exception:
+            group_id = None
+
+        try:
+            if group_id is not None:
+                os.killpg(group_id, signal.SIGTERM)
+            else:
+                process.terminate()
+            process.wait(timeout=5)
+            console.print(f"[dim]🛑 {framework}: Dev server stopped[/dim]")
+        except Exception:
+            try:
+                if group_id is not None:
+                    os.killpg(group_id, signal.SIGKILL)
+                else:
+                    process.kill()
+                process.wait(timeout=2)
+            except Exception:
+                pass
+
     def run_single_benchmark(self, framework: str) -> BenchmarkResult:
         """Measure dev server startup and HMR speed for a single framework."""
         try:
@@ -326,7 +351,10 @@ class DevServerRunner(BenchmarkRunner):
                 cwd=framework_dir,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                text=True
+                text=True,
+                # Own process group, so cleanup can reach the dev server itself
+                # and not just the shell wrapping it
+                start_new_session=True
             )
             
             try:
@@ -353,17 +381,8 @@ class DevServerRunner(BenchmarkRunner):
                 })
                 
             finally:
-                # Always cleanup the dev server
-                try:
-                    process.terminate()
-                    process.wait(timeout=5)
-                    console.print(f"[dim]🛑 {framework}: Dev server stopped[/dim]")
-                except Exception:
-                    try:
-                        process.kill()
-                        process.wait(timeout=2)
-                    except Exception:
-                        pass
+                # Always cleanup the dev server (and any child it spawned)
+                self._terminate_process_group(process, framework)
                 
         except subprocess.TimeoutExpired:
             return self._create_error_result(framework, "Dev server startup timed out")

--- a/scripts/transform/build_app_readme.py
+++ b/scripts/transform/build_app_readme.py
@@ -156,15 +156,19 @@ def update_readme(framework: Dict, content_sections: Dict[str, str]) -> None:
     readme_path = Path(f"apps/{fw_dir}/README.md")
     
     if not readme_path.exists():
+        real_world_app = (
+            f"{content_sections['real_world_app']}\n\n"
+            if content_sections['real_world_app'] else ""
+        )
         content = (
             f"{content_sections['header']}\n\n"
             f"{content_sections['about']}\n\n"
             f"{content_sections['status']}\n\n"
             f"{content_sections['usage']}\n\n"
-            f"{content_sections['real_world_app']}\n\n" if content_sections['real_world_app'] else ""
             "<!-- start_framework_specific -->\n\n"
             "<!-- Framework-specific notes go here -->\n\n"
             "<!-- end_framework_specific -->\n\n"
+            f"{real_world_app}"
             f"{content_sections['license']}"
         )
         try:


### PR DESCRIPTION
Two small bugs I ran into while benchmarking locally. Unrelated to each other, but both one-liners in spirit, so I've kept them together.

**Dev servers were surviving the benchmark.** `dev_server.py` starts them with `shell=True`, then cleans up with `process.terminate()`. That only signals the shell, so the dev server itself carries on running and holds its port. Most of the time you just end up with an orphan process, but any CLI that writes a lock file will then refuse to start on the next run. They now get their own process group, and cleanup signals the group.

**New app READMEs were coming out truncated.** There's a misparenthesized ternary in the create-a-new-file path of `build_app_readme.py`:

```python
f"{sections['real_world_app']}\n\n" if sections['real_world_app'] else ""
"<!-- start_framework_specific -->\n\n"
```

The conditional binds to the whole expression, so everything after it becomes part of the `else` branch. A freshly generated README silently loses its framework specific block and the entire license footer. Existing READMEs go down the update path instead, which is why this has never shown up.

Tested locally, and I ran the Lint and Test workflows on my fork against this branch, both passing.