### PR TITLE
fix(ci): build website from latest benchmark results

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,6 +236,22 @@ jobs:
           npm ci
           python scripts/setup/main.py --skip-build
 
+      # Scheduled benchmark runs always publish to the `results` branch, but only
+      # commit to main when manually dispatched with commit_to_main=true. The site
+      # is built from main, so without this it renders whatever snapshot happened to
+      # be committed last - omitting every framework added since.
+      - name: Sync latest benchmark results
+        run: |
+          if git fetch --depth=1 origin results 2>/dev/null \
+            && git show FETCH_HEAD:summary/summary.json > /tmp/summary.json 2>/dev/null \
+            && python -c "import json; json.load(open('/tmp/summary.json'))" 2>/dev/null; then
+            mv /tmp/summary.json results/summary.json
+            echo "✅ Synced benchmark results from the results branch"
+            python -c "import json; d = json.load(open('results/summary.json')); print('   generated:', d.get('metadata', {}).get('generated_at', 'unknown')); print('   frameworks:', ', '.join(sorted(d.get('frameworks', {}))))"
+          else
+            echo "::warning::Could not read summary/summary.json from the results branch - building with the committed results/summary.json, which may be out of date"
+          fi
+
       - name: Build all frameworks and generate website
         run: |
           echo "Building all frameworks for comparison website..."


### PR DESCRIPTION
Thanks for merging #26 (Gea)! While looking at it I noticed the comparison page isn't showing results for Gea or Astro: selecting either on its own leaves every chart empty. This PR is an attempt to fix that.

## Cause

The site builds its charts from `results/summary.json` on main, which has been frozen since 2025-09-09, so anything added after that date renders empty.

`benchmark.yml` sets `COMMIT_TO_MAIN=false` on scheduled runs, and `transform-results.yml` gates its "Commit to Main Branch" step on that flag. The `results` branch is therefore refreshed nightly while main's copy only updates on a manual `workflow_dispatch` with `commit_to_main: true`. `build.yml` builds from main.

The chain is `results/summary.json` → `build_charts.py:981` → `website/static/chart-configs.json` → `generator.py:204` → `homepage.html:247` (`const chartConfigs`). The deployed chart labels match main's stale snapshot exactly: `Alpine Angular Jquery Lit Preact Qwik React Solid Svelte Vanilla Vanjs Vue Lume-Js`, with no Astro and no Gea.

## Regression

Two commits on 2025-08-24:

```
139f504  Commits results to the results branch
0291354  Allows benchmarking to run as a cron, and skip commiting of results
```

Cron runs skipping main is clearly deliberate, and this PR preserves that. The unintended half is that the website build was never repointed at the `results` branch. The automated `chore(results): update benchmark summaries from run #N` commits stop at run #22 on 2025-08-23, the day before.

What follows looks like manual patching: be29a52 (2025-08-29) and df65ea9 (2025-09-09) hand-commit the exact files the pipeline had stopped writing. Since then the only change to `results/summary.json` was 77d721f (2026-05-09), which edited Lume.js's numbers into the old snapshot without touching `generated_at`. That is why Lume.js renders and Astro does not.

## Fix

Sync `summary/summary.json` from the `results` branch into the build working tree before generating the site. Nothing is committed, so the cron policy is unchanged. If the branch is unreachable (forks), it warns and falls back to the committed file.

Verified:

- Synced data gives `generated: 2026-08-04` and 14 frameworks including Astro, against 13 and no Astro committed.
- Re-ran `build_charts.py`: `bundle_size_comparison` and `performance_radar` now include Astro.
- Fallback path tested against a missing branch: warning, exit 0, builds from the committed file.

## Notes

Gea has never run in CI, since #26 merged 45 minutes after that day's cron had already checked out main. Because `geajs` is in `frameworks.json` and `common.py:27` reads it unfiltered, the next scheduled run picks it up and this change carries it through to the site. Its CI build is therefore still unproven.

The Workflow Audit failure is pre-existing: 10 `ref-version-mismatch` warnings on `uses:` pins this diff does not touch, two of them in `benchmark.yml`. That job only runs when a workflow file changes, so it will fail any such PR until the pin comments are refreshed.

---

*Disclosure: this PR was investigated and drafted with AI assistance (Claude Code).*
